### PR TITLE
Label hiding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the CSS on the `hide_label()` method to prevent affecting child elements.
+
 ## [1.1.3] - 2017-11-27
 
 ## Changed

--- a/src/Codifier.php
+++ b/src/Codifier.php
@@ -43,7 +43,7 @@ class Codifier {
 
                 $key = str_replace( '_', '-', $key );
 
-                echo 'div.acf-field.acf-field-' . $key . " label { display: none; }\n";
+                echo 'div.acf-field.acf-field-' . esc_attr( $key ) . " > div.acf-label > label { display: none; }\n";
             }
 
             echo "</style>\n";


### PR DESCRIPTION
### Fixed

- Fixed the CSS on the `hide_label()` method to prevent affecting child elements.