### PR TITLE
FlexibleContent fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Removed array_unique check from FlexibleContent as it doesn't work
+
 ## [1.4.0] - 2018-02-13
 
 ### Added

--- a/src/Field/FlexibleContent.php
+++ b/src/Field/FlexibleContent.php
@@ -43,7 +43,7 @@ class FlexibleContent extends \Geniem\ACF\Field {
      *
      * @var array
      */
-    protected $layouts;
+    protected $layouts = [];
 
     /**
      * Exclude layouts from post types
@@ -210,8 +210,6 @@ class FlexibleContent extends \Geniem\ACF\Field {
         $name = $layout->get_name();
 
         $this->layouts[ $name ] = $layout;
-
-        $this->layouts = array_unique( $this->layouts );
 
         return $this;
     }


### PR DESCRIPTION
Removed the array_unique check from add_layout function as it will create an error when adding a second layout because array_unique tests by transforming the check targets intro strings, and even if it worked it would not do much as the layouts are added by their name so they should anyways be unique