### PR TITLE
set conditional_logic to be an empty array by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Set `Field->$conditional_logic` to be an empty array by default as otherwise it causes a warning in GroupableField.php:81
+
 ## [1.9.2] - 2018-04-12
 
 ### Fixed

--- a/src/Field.php
+++ b/src/Field.php
@@ -49,7 +49,7 @@ abstract class Field {
      *
      * @var array
      */
-    protected $conditional_logic;
+    protected $conditional_logic = [];
 
     /**
      * Default value for the field.


### PR DESCRIPTION
### Fixed
- Set `Field->$conditional_logic` to be an empty array by default as otherwise it causes a warning in GroupableField.php:81
