### PR TITLE
Unique field type for gravity_forms

### DIFF
--- a/src/Field/GravityForms.php
+++ b/src/Field/GravityForms.php
@@ -11,6 +11,13 @@ namespace Geniem\ACF\Field;
 class GravityForms extends \Geniem\ACF\Field\Select {
 
     /**
+     * Field type
+     *
+     * @var string
+     */
+    protected $type = 'gravity_forms';
+
+    /**
      * Constructor.
      *
      * @param string      $label          Label for the field.


### PR DESCRIPTION
Unique field type `gravity_forms` for GravityForms fields.
Now all gravity form fields have the type of select if developer wants to filter globally all gravity form fields it isn't possible easily.