### PR TITLE
Add delay attribute to wysiwyg editor initialization

### DIFF
--- a/docs/classes.md
+++ b/docs/classes.md
@@ -266,6 +266,9 @@
 |:-----------|:---------|
 | public | <strong>allow_media_upload()</strong> : <em>[\Geniem\ACF\Field](#class-geniemacffield-abstract)\self</em><br /><em>Allow media upload</em> |
 | public | <strong>disable_media_upload()</strong> : <em>[\Geniem\ACF\Field](#class-geniemacffield-abstract)\self</em><br /><em>Disable media upload</em> |
+| public | <strong>disable_delay()</strong> : <em>[\Geniem\ACF\Field](#class-geniemacffield-abstract)\self</em><br /><em>Disable delay of the wysiwyg editor initialization</em> |
+| public | <strong>enable_delay()</strong> : <em>[\Geniem\ACF\Field](#class-geniemacffield-abstract)\self</em><br /><em>Enable delay of the wysiwyg editor initialization</em> |
+| public | <strong>get_delay()</strong> : <em>boolean</em><br /><em>Get wysiwyg initialization delay state</em> |
 | public | <strong>get_media_upload()</strong> : <em>boolean</em><br /><em>Get media upload state</em> |
 | public | <strong>get_tabs()</strong> : <em>string</em><br /><em>Get allowed tabs</em> |
 | public | <strong>get_toolbar()</strong> : <em>string</em><br /><em>Get what toolbars to show</em> |
@@ -1235,4 +1238,3 @@
 | public | <strong>set_label(</strong><em>\string</em> <strong>$label</strong>)</strong> : <em>[\Geniem\ACF\Field\MediumEditor](#class-geniemacffieldmediumeditor)\self</em><br /><em>Set button label</em> |
 | public | <strong>set_name(</strong><em>\string</em> <strong>$name</strong>)</strong> : <em>[\Geniem\ACF\Field\MediumEditor](#class-geniemacffieldmediumeditor)\self</em><br /><em>Set name</em> |
 | public | <strong>set_tag(</strong><em>\string</em> <strong>$tag</strong>)</strong> : <em>[\Geniem\ACF\Field\MediumEditor](#class-geniemacffieldmediumeditor)\self</em><br /><em>Set the HTML tag to be used.</em> |
-

--- a/src/Field/Wysiwyg.php
+++ b/src/Field/Wysiwyg.php
@@ -38,6 +38,13 @@ class Wysiwyg extends \Geniem\ACF\Field {
     protected $media_upload = 1;
 
     /**
+     * Delay initialization of the wysiwyg editor
+     *
+     * @var integer
+     */
+    protected $delay = 0;
+
+    /**
      * Set tabs to show
      *
      * @throws \Geniem\ACF\Exception Throws error if $tabs is not valid.
@@ -113,5 +120,36 @@ class Wysiwyg extends \Geniem\ACF\Field {
      */
     public function get_media_upload() {
         return $this->media_upload;
+    }
+
+    /**
+     * Enable delay of the wysiwyg editor initialization
+     *
+     * @return self
+     */
+    public function enable_delay() {
+        $this->delay = 1;
+
+        return $this;
+    }
+
+    /**
+     * Disable delay of the wysiwyg editor initialization
+     *
+     * @return self
+     */
+    public function disable_delay() {
+        $this->delay = 0;
+
+        return $this;
+    }
+
+    /**
+     * Get wysiwyg initialization delay state
+     *
+     * @return integer
+     */
+    public function get_delay() {
+        return $this->delay;
     }
 }


### PR DESCRIPTION
When page has many wysiwyg editor fields it takes time to initialize all of them. Setting wysiwyg editor delay initializes editor only when user clicks it.