### PR TITLE
redipress_include_search_filter to pass integer values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.35.1] - 2021-01-25
 
 ### Fixed
+- Changes `redipress_get_fields()` has_blocks check to use $item->post_content.
 - Fixes the `redipress_include_search_filter()` to pass integer values.
 ## [1.35.0] - 2020-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.35.1] - 2021-01-25
+
+### Fixed
+- Fixes the `redipress_include_search_filter()` to pass integer values.
 ## [1.35.0] - 2020-11-16
 
 ### Added

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: ACF Codifier
 Plugin URI: https://github.com/devgeniem/acf-codifier
 Description: A helper class to make defining ACF field groups and fields easier in the code.
-Version: 1.35.0
+Version: 1.35.1
 Author: Miika Arponen / Geniem Oy
 Author URI: https://geniem.fi
 License: GPL-3.0

--- a/src/Field.php
+++ b/src/Field.php
@@ -1165,7 +1165,8 @@ abstract class Field {
         }
 
         if ( $item instanceof \WP_Post ) {
-            if ( \has_blocks( $item ) ) {
+
+            if ( \has_blocks( $item->post_content ) ) {
                 $blocks = parse_blocks( $item->post_content );
 
                 array_walk( $blocks, function( $block ) {

--- a/src/Field.php
+++ b/src/Field.php
@@ -787,7 +787,7 @@ abstract class Field {
                     $redipress_value = $value;
                 }
 
-                if ( is_string( $redipress_value ) || is_array( $redipress_value ) ) {
+                if ( is_string( $redipress_value ) || is_array( $redipress_value ) || is_int( $redipress_value ) ) {
                     if ( strpos( $post_id, 'block_' ) !== false &&
                         ! ( $post_id = \Geniem\RediPress\Index\Index::indexing() ) // phpcs:ignore
                     ) {


### PR DESCRIPTION
- Fixes the `redipress_include_search_filter()` to pass integer values.