### PR TITLE
Fix Polylang incompatibility with multisite fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### Fixed
+- Fix Polylang incompatibility with multisite fields.
+
 ## [1.37.0] - 2021-11-30
 
 ### Changed

--- a/src/Fields/MultisitePostObject.php
+++ b/src/Fields/MultisitePostObject.php
@@ -116,7 +116,22 @@ add_action(
              */
             public function render_field( $field ) {
                 \switch_to_blog( $field['blog_id'] );
-                parent::render_field( $field );
+
+                // If Polylang is active, we need to switch the global curlang manually
+                // as switch_to_blog does not do that in admin views.
+                // If this is not done, the field may not find its saved value if the taxonomy term IDs
+                // do not match between all sites.
+                if ( function_exists( 'pll_default_language' ) ) {
+                    $restore_curlang = \PLL()->curlang;
+                    $lang = \PLL()->model->get_language( $restore_curlang->slug );
+                    \PLL()->curlang = $lang ?: \PLL()->model->get_language( \pll_default_language() );
+                    parent::render_field( $field );
+                    \PLL()->curlang = $restore_curlang;
+                }
+                else {
+                    parent::render_field( $field );
+                }
+
                 \restore_current_blog();
             }
 

--- a/src/Fields/MultisiteRelationship.php
+++ b/src/Fields/MultisiteRelationship.php
@@ -124,7 +124,20 @@ add_action( 'acf/init', function() {
         public function render_field( $field ) {
             \switch_to_blog( $field['blog_id'] );
 
-            parent::render_field( $field );
+            // If Polylang is active, we need to switch the global curlang manually
+            // as switch_to_blog does not do that in admin views.
+            // If this is not done, the field may not find its saved value if the taxonomy term IDs
+            // do not match between both sites.
+            if ( function_exists( 'pll_default_language' ) ) {
+                $restore_curlang = \PLL()->curlang;
+                $lang = \PLL()->model->get_language( $restore_curlang->slug );
+                \PLL()->curlang = $lang ?: \PLL()->model->get_language( \pll_default_language() );
+                parent::render_field( $field );
+                \PLL()->curlang = $restore_curlang;
+            }
+            else {
+                parent::render_field( $field );
+            }
 
             \restore_current_blog();
         }


### PR DESCRIPTION
When running `switch_to_blog` on the admin side, Polylang does not update its internal `curlang`. This causes problems if languages have different term IDs between both sites. In other words, Polylang adds its language tax query ID according to the site where the request is initiated, not the blog which the query targets. If the IDs don't match, Codifier does not populate the saved values into rendered fields.