### PR TITLE
Automatic conversion of false to array is deprecated hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+[unreleased]
+
+[php-81-automatic-conversion-hotfix]
+### Fixed
+- Fixes "Automatic conversion of false to array is deprecated" on Dust.php
+
+[released]
 ## [1.38.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-[unreleased]
+[Unreleased]
 
 [php-81-automatic-conversion-hotfix]
 ### Fixed
 - Fixes "Automatic conversion of false to array is deprecated" on Dust.php
 
-[released]
 ## [1.38.1]
 
 ### Fixed

--- a/src/Renderer/Dust.php
+++ b/src/Renderer/Dust.php
@@ -73,6 +73,12 @@ class Dust implements Renderer {
     public function render( array $fields ) : string {
         $compiled = self::$dust->compileFile( $this->template );
 
+        // In same cases this might be false.
+        // We need to set key as an array after PHP 8.1 in these situations.
+        if ( empty( $fields['data'] ) ) {
+            $fields['data'] = [];
+        }
+
         // Pass on the block data
         $fields['data']['block'] = $fields['block'];
 


### PR DESCRIPTION
### Fixed
- Fixes "Automatic conversion of false to array is deprecated" on Dust.php