### PR TITLE
Fix undefined method error in RediPress functionalities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]
 
+## [1.38.3]
+### Fixed
+- Fixes undefined method error in RediPress functionalities
+
 ## [1.38.2]
 ### Fixed
 - Fixes "Automatic conversion of false to array is deprecated" on Dust.php

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: ACF Codifier
 Plugin URI: https://github.com/devgeniem/acf-codifier
 Description: A helper class to make defining ACF field groups and fields easier in the code.
-Version: 1.38.0
+Version: 1.38.3
 Author: Miika Arponen / Geniem Oy
 Author URI: https://geniem.fi
 License: GPL-3.0

--- a/src/Field.php
+++ b/src/Field.php
@@ -805,7 +805,7 @@ abstract class Field {
 
                 if ( is_string( $redipress_value ) || is_array( $redipress_value ) || is_int( $redipress_value ) ) {
                     if ( strpos( $post_id, 'block_' ) !== false &&
-                        ! ( $post_id = \Geniem\RediPress\Index\Index::indexing() ) // phpcs:ignore
+                        ! ( $post_id = \Geniem\RediPress\Index\PostIndex::indexing() ) // phpcs:ignore
                     ) {
                         $document_uri = filter_input( INPUT_SERVER, 'DOCUMENT_URI', \FILTER_SANITIZE_STRING );
 
@@ -924,7 +924,7 @@ abstract class Field {
                     $doc_id = \Geniem\RediPress\Index\PostIndex::get_document_id( get_post( $post_id ) );
                 }
                 elseif ( strpos( $post_id, 'block_' ) !== false ) {
-                    if ( ! ( $post_id = \Geniem\RediPress\Index\Index::indexing() ) ) {
+                    if ( ! ( $post_id = \Geniem\RediPress\Index\PostIndex::indexing() ) ) {
                         $document_uri = filter_input( INPUT_SERVER, 'DOCUMENT_URI', \FILTER_SANITIZE_STRING );
 
                         $post_id = basename( $document_uri );


### PR DESCRIPTION
Fixes

```
Fatal error: Uncaught Error: Call to undefined method Geniem\RediPress\Index\Index::indexing()
```

when indexing.