### PR TITLE
Add support for block parent attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]
 
+## [1.39.0]
+
+### Added
+- Add support for block parent attribute.
+
 ## [1.38.4]
 
 - Fix previous tag pointing to earlier commit.

--- a/docs/classes.md
+++ b/docs/classes.md
@@ -233,6 +233,7 @@
 | public | <strong>get_keywords()</strong> : <em>array</em><br /><em>Getter for the keywords.</em> |
 | public | <strong>get_mode()</strong> : <em>string</em><br /><em>Getter for the display mode.</em> |
 | public | <strong>get_name()</strong> : <em>string</em><br /><em>Getter for the name.</em> |
+| public | <strong>get_parent()</strong> : <em>array|null</em><br /><em>Getter for the parent of the block.</em> |
 | public | <strong>get_post_types()</strong> : <em>array</em><br /><em>Getter for the post types.</em> |
 | public | <strong>get_renderer()</strong> : <em>[\Geniem\ACF\Interfaces\Renderer](#interface-geniemacfinterfacesrenderer)</em><br /><em>Getter for the component renderer.</em> |
 | public | <strong>get_styles()</strong> : <em>array</em><br /><em>Getter for the styles of the block.</em> |
@@ -253,6 +254,7 @@
 | public | <strong>set_keywords(</strong><em>array</em> <strong>$keywords</strong>)</strong> : <em>\Geniem\ACF\self</em><br /><em>Setter for the keywords.</em> |
 | public | <strong>set_mode(</strong><em>\string</em> <strong>$mode</strong>)</strong> : <em>\Geniem\ACF\self</em><br /><em>Setter for the display mode Options: auto, preview or edit.</em> |
 | public | <strong>set_name(</strong><em>\string</em> <strong>$name</strong>)</strong> : <em>\Geniem\ACF\self</em><br /><em>Setter for the name.</em> |
+| public | <strong>set_parent(</strong><em>\array|null</em> <strong>$parent</strong>)</strong> : <em>\Geniem\ACF\self</em><br /><em>Setter for the parent of the block.</em> |
 | public | <strong>set_post_types(</strong><em>array</em> <strong>$post_types</strong>)</strong> : <em>\Geniem\ACF\self</em><br /><em>Setter for the post_ ypes.</em> |
 | public | <strong>set_renderer(</strong><em>[\Geniem\ACF\Interfaces\Renderer](#interface-geniemacfinterfacesrenderer)</em> <strong>$renderer</strong>)</strong> : <em>void</em><br /><em>Set the renderer for the component.</em> |
 | public | <strong>set_styles(</strong><em>array</em> <strong>$styles</strong>)</strong> : <em>\Geniem\ACF\self</em><br /><em>Setter for the styles of the block.</em> |

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: ACF Codifier
 Plugin URI: https://github.com/devgeniem/acf-codifier
 Description: A helper class to make defining ACF field groups and fields easier in the code.
-Version: 1.38.4
+Version: 1.39.0
 Author: Miika Arponen / Geniem Oy
 Author URI: https://geniem.fi
 License: GPL-3.0

--- a/src/Block.php
+++ b/src/Block.php
@@ -115,6 +115,15 @@ class Block implements GroupableInterface {
     protected $styles = [];
 
     /**
+     * An array of parent blocks for the block.
+     *
+     * @see https://developer.wordpress.org/block-editor/developers/block-api/block-registration/#parent-optional
+     *
+     * @var array|null
+     */
+    protected $parent = null;
+
+    /**
      * The renderer for this block.
      *
      * @var Renderer
@@ -450,6 +459,27 @@ class Block implements GroupableInterface {
     }
 
     /**
+     * Setter for the parent of the block.
+     *
+     * @param array|null $parent Array of parent blocks or null.
+     * @return self
+     */
+    public function set_parent( ?array $parent ) : self {
+        $this->parent = $parent;
+
+        return $this;
+    }
+
+    /**
+     * Getter for the parent of the block.
+     *
+     * @return array|null
+     */
+    public function get_parent() : ?array {
+        return $this->parent;
+    }
+
+    /**
      * Add a data filtering function for the block
      *
      * @param callable $function The function to add.
@@ -546,6 +576,7 @@ class Block implements GroupableInterface {
             'align'           => $this->get_align(),
             'supports'        => $this->get_supports(),
             'styles'          => $this->get_styles(),
+            'parent'          => $this->get_parent(),
         ];
 
         if ( ! empty( $this->get_post_types() ) ) {


### PR DESCRIPTION
Support ACF `parent` attribute for blocks to limit using the registered block only as a child of a specified parent or parents.

`$parents` is of type `array|null` since setting it as an empty array limits the block visibility altogether (it has no parents and cannot be added anywhere).