### PR TITLE
Add support for bidirectional relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]
 
+### Added
+- Support for ACF native bidirectional relationships. See https://www.advancedcustomfields.com/resources/bidirectional-relationships/.
+
 ## [1.40.0]
 
 ### Added

--- a/readme.md
+++ b/readme.md
@@ -233,6 +233,15 @@ $pseudo->add_field( $some_field )
        ->add_field( $another_field );
 ```
 
+#### Bidirectional relationships
+
+Codifier supports bidirectional relationships for the field types ACF is supporting the feature (currently PostObject, Relationship, Taxonomy and User).
+
+```php
+$field->set_bidirectional()
+      ->set_bidirectional_targets( [ 'field_name_or_key' ] );
+```
+
 ## Gutenberg
 
 Codifier has a feature to register Gutenberg blocks using ACF's register block feature internally. It works in a very similar fashion than the basic field creation in Codifier as well.

--- a/src/Field/Common/Bidirectional.php
+++ b/src/Field/Common/Bidirectional.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * ACF Codifier bidirectional trait
+ */
+
+namespace Geniem\ACF\Field\Common;
+
+/**
+ * Bidirectional trait
+ */
+trait Bidirectional {
+    /**
+     * Field bidirectional status.
+     *
+     * @var boolean
+     */
+    protected $bidirectional = 0;
+
+    /**
+     * Bidirectional targets.
+     *
+     * @var array
+     */
+    protected $bidirectional_target = [];
+
+    /**
+     * Set bidirectional.
+     *
+     * @return self
+     */
+    public function set_bidirectional() {
+        $this->bidirectional = 1;
+
+        return $this;
+    }
+
+    /**
+     * Set unidirectional (disable bidirectional).
+     *
+     * @return self
+     */
+    public function set_unidirectional() {
+        $this->bidirectional = 0;
+
+        return $this;
+    }
+
+    /**
+     * Get bidirectional status.
+     *
+     * @return boolean
+     */
+    public function get_bidirectional() {
+        return $this->bidirectional;
+    }
+
+    /**
+     * Set bidirectional targets.
+     *
+     * @param array $targets Target field names or keys.
+     * @return self
+     */
+    public function set_bidirectional_targets( array $targets = [] ) {
+        $this->bidirectional_target = $targets;
+
+        return $this;
+    }
+
+    /**
+     * Add bidirectional target.
+     *
+     * @param string $target Target field name or key.
+     * @return self
+     */
+    public function add_bidirectional_target( string $target ) {
+        $this->bidirectional_target[] = $target;
+
+        return $this;
+    }
+
+    /**
+     * Remove bidirectional target.
+     *
+     * @param string $target Target field name or key.
+     * @return self
+     */
+    public function remove_bidirectional_target( string $target ) {
+        $key = array_search( $target, $this->bidirectional_target );
+
+        if ( $key !== false ) {
+            unset( $this->bidirectional_target[ $key ] );
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get bidirectional targets.
+     *
+     * @return array
+     */
+    public function get_bidirectional_targets() {
+        return $this->bidirectional_target;
+    }
+}

--- a/src/Field/PostObject.php
+++ b/src/Field/PostObject.php
@@ -5,10 +5,15 @@
 
 namespace Geniem\ACF\Field;
 
+use Geniem\ACF\Field\Common\Bidirectional;
+
 /**
  * Class PostObject
  */
 class PostObject extends \Geniem\ACF\Field {
+
+    use Bidirectional;
+
     /**
      * Field type
      *

--- a/src/Field/Relationship.php
+++ b/src/Field/Relationship.php
@@ -5,6 +5,7 @@
 
 namespace Geniem\ACF\Field;
 
+use Geniem\ACF\Field\Common\Bidirectional;
 use Geniem\ACF\Field\Common\MinMax;
 
 /**
@@ -12,7 +13,7 @@ use Geniem\ACF\Field\Common\MinMax;
  */
 class Relationship extends \Geniem\ACF\Field {
 
-    use MinMax;
+    use Bidirectional, MinMax;
 
     /**
      * Field type

--- a/src/Field/Taxonomy.php
+++ b/src/Field/Taxonomy.php
@@ -5,6 +5,7 @@
 
 namespace Geniem\ACF\Field;
 
+use Geniem\ACF\Field\Common\Bidirectional;
 use Geniem\ACF\Field\Common\Disabled;
 
 /**
@@ -12,7 +13,7 @@ use Geniem\ACF\Field\Common\Disabled;
  */
 class Taxonomy extends \Geniem\ACF\Field {
 
-    use Disabled;
+    use Bidirectional, Disabled;
 
     /**
      * Field type

--- a/src/Field/User.php
+++ b/src/Field/User.php
@@ -5,10 +5,15 @@
 
 namespace Geniem\ACF\Field;
 
+use Geniem\ACF\Field\Common\Bidirectional;
+
 /**
  * Class User
  */
 class User extends \Geniem\ACF\Field {
+
+    use Bidirectional;
+
     /**
      * Field type
      *


### PR DESCRIPTION
ACF supports [native bidirectional relationships](https://www.advancedcustomfields.com/resources/bidirectional-relationships/). This change adds support for the feature for the field types ACF supports: PostObject, Relationship, Taxonomy and User.

As a side note, could not update `docs` with the Composer command because of PHP incompatibilities.