### PR TITLE
Support float step sizes and enforce validation in the set_step method for Number field

### DIFF
--- a/src/Field/Number.php
+++ b/src/Field/Number.php
@@ -42,10 +42,20 @@ class Number extends \Geniem\ACF\Field {
     /**
      * Set step size
      *
-     * @param integer $step Step size.
+     * @param integer|float $step Step size.
      * @return self
      */
-    public function set_step( int $step ) {
+    public function set_step( $step ) {
+        // Validate that the step is numeric
+        if ( ! is_numeric( $step ) ) {
+            throw new \Geniem\ACF\Exception( 'Geniem\ACF\Field\Number: set_step() only accepts numeric values' );
+        }
+
+        // Ensure the step is positive
+        if ( $step <= 0 ) {
+            throw new \Geniem\ACF\Exception( 'Geniem\ACF\Field\Number: set_step() only accepts positive values' );
+        }
+
         $this->step = $step;
 
         return $this;
@@ -54,7 +64,7 @@ class Number extends \Geniem\ACF\Field {
     /**
      * Get step size
      *
-     * @return integer
+     * @return integer|float
      */
     public function get_step() {
         return $this->step;


### PR DESCRIPTION
- Updated set_step to allow float step sizes
- Added validation to ensure the step size is a positive numeric value, as negative step sizes have no effect in the step attribute of HTML inputs