### PR TITLE
Update block parent handling for WP 6.8 compatibility

### DIFF
--- a/src/Block.php
+++ b/src/Block.php
@@ -576,11 +576,16 @@ class Block implements GroupableInterface {
             'align'           => $this->get_align(),
             'supports'        => $this->get_supports(),
             'styles'          => $this->get_styles(),
-            'parent'          => $this->get_parent(),
         ];
 
-        if ( ! empty( $this->get_post_types() ) ) {
-            $args['post_types'] = $this->get_post_types();
+        $parent = $this->get_parent();
+        if ( ! empty( $parent ) ) {
+            $args['parent'] = $parent;
+        }
+
+        $post_types = $this->get_post_types();
+        if ( ! empty( $post_types ) ) {
+            $args['post_types'] = $post_types;
         }
 
         // Register the ACF Block.


### PR DESCRIPTION
In WordPress 6.8, there was a change in how the Gutenberg block registration system handles the parent property. According to [this forum thread](https://support.advancedcustomfields.com/forums/topic/wp-6-8-gutenberg-blocks-wont-register/), the parent property must now be either an array or undefined - passing null causes block registration to fail with the error: `Uncaught TypeError: Cannot read properties of undefined (reading 'attributes')`